### PR TITLE
Support a processCwd option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,21 @@ const { fileList } = await nodeFileTrace(files, {
 
 Any files/folders above the `base` are ignored in the listing and analysis.
 
+#### Process Cwd
+
+When applying analysis certain functions rely on the `process.cwd()` value, such as `path.resolve('./relative')` or even a direct `process.cwd()`
+invocation.
+
+Setting the `processCwd` option allows this analysis to be guided to the right path to ensure that assets are correctly detected.
+
+```js
+const { fileList } = await nodeFileTrace(files, {
+  processCwd: path.resolve(__dirname)
+}
+```
+
+By default `processCwd` is the same as `base`.
+
 #### Paths
 
 > Status: Experimental. May change at any time.

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -173,7 +173,7 @@ module.exports = async function (id, code, job) {
   const dir = path.dirname(id);
   // if (typeof options.production === 'boolean' && staticProcess.env.NODE_ENV === UNKNOWN)
   //  staticProcess.env.NODE_ENV = options.production ? 'production' : 'dev';
-  cwd = job.base;
+  cwd = job.cwd;
   const pkgBase = getPackageBase(id);
 
   const emitAssetDirectory = (wildcardPath) => {

--- a/src/node-file-trace.js
+++ b/src/node-file-trace.js
@@ -42,6 +42,7 @@ module.exports = async function (files, opts = {}) {
 class Job {
   constructor ({
     base = process.cwd(),
+    processCwd,
     paths = {},
     ignore,
     log = false,
@@ -71,6 +72,7 @@ class Job {
       }
     }
     this.base = base;
+    this.cwd = resolve(processCwd || base);
     const resolvedPaths = {};
     for (const path of Object.keys(paths)) {
       const trailer = paths[path].endsWith('/');

--- a/src/utils/wrappers.js
+++ b/src/utils/wrappers.js
@@ -309,9 +309,12 @@ function handleWrappers (ast) {
         wrapper.callee.body.body[0].type === 'VariableDeclaration' &&
         wrapper.callee.body.body[0].declarations.length === 1 &&
         wrapper.callee.body.body[0].declarations[0].type === 'VariableDeclarator' &&
-        wrapper.callee.body.body[0].declarations[0].id.type === 'Identifier' &&
-        wrapper.callee.body.body[0].declarations[0].init.type === 'ObjectExpression' &&
-        wrapper.callee.body.body[0].declarations[0].init.properties.length === 0 &&
+        wrapper.callee.body.body[0].declarations[0].id.type === 'Identifier' && (
+          wrapper.callee.body.body[0].declarations[0].init.type === 'ObjectExpression' &&
+          wrapper.callee.body.body[0].declarations[0].init.properties.length === 0 ||
+          wrapper.callee.body.body[0].declarations[0].init.type === 'CallExpression' &&
+          wrapper.callee.body.body[0].declarations[0].init.arguments.length === 1
+        ) &&
         wrapper.callee.body.body[1].type === 'FunctionDeclaration' &&
         wrapper.callee.body.body[1].params.length === 1 &&
         wrapper.callee.body.body[1].body.body.length >= 3 && (

--- a/test/ecmascript.test.js
+++ b/test/ecmascript.test.js
@@ -42,6 +42,7 @@ async function runTests(importPath) {
         await writeFile(filename, str, 'utf8');
         const { fileList, warnings } = await nodeFileTrace([filename], {
           base: `${__dirname}/../`,
+          processCwd: path.dirname(filename),
           ts: true,
           log: true,
           mixedModules: true

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -13,13 +13,16 @@ const { fork } = require('child_process');
 
 jest.setTimeout(200000);
 
-for (const integrationTest of fs.readdirSync(`${__dirname}/integration`)) {
+const integrationDir = `${__dirname}/integration`;
+
+for (const integrationTest of fs.readdirSync(integrationDir)) {
   it(`should correctly trace and correctly execute ${integrationTest}`, async () => {
     console.log('Tracing and executing ' + integrationTest);
     const fails = integrationTest.endsWith('failure.js');
-    const { fileList, reasons, warnings } = await nodeFileTrace([`${__dirname}/integration/${integrationTest}`], {
+    const { fileList, reasons, warnings } = await nodeFileTrace([`${integrationDir}/${integrationTest}`], {
       log: true,
       base: path.resolve(__dirname, '..'),
+      processCwd: integrationDir,
       // ignore other integration tests
       ignore: ['test/integration/**']
     });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -13,7 +13,7 @@ const { fork } = require('child_process');
 
 jest.setTimeout(200000);
 
-const integrationDir = `${__dirname}/integration`;
+const integrationDir = `${__dirname}${path.sep}integration`;
 
 for (const integrationTest of fs.readdirSync(integrationDir)) {
   it(`should correctly trace and correctly execute ${integrationTest}`, async () => {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -51,6 +51,7 @@ for (const unitTest of fs.readdirSync(join(__dirname, 'unit'))) {
 
     const { fileList, reasons } = await nodeFileTrace([join(unitPath, inputFileName)], {
       base: `${__dirname}/../`,
+      processCwd: unitPath,
       paths: {
         dep: 'test/unit/esm-paths/esm-dep.js',
         'dep/': 'test/unit/esm-paths-trailer/'

--- a/test/unit/webpack-wrapper-strs-namespaces/input.js
+++ b/test/unit/webpack-wrapper-strs-namespaces/input.js
@@ -1,7 +1,7 @@
 module.exports =
 /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
-/******/ 	var installedModules = {};
+/******/ 	var installedModules = require('path');
 /******/
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {

--- a/test/unit/webpack-wrapper-strs-namespaces/input.js
+++ b/test/unit/webpack-wrapper-strs-namespaces/input.js
@@ -114,7 +114,7 @@ __webpack_require__.r(__webpack_exports__);
 
 
 function handler(req, res) {
-  const dictionaryPath = path__WEBPACK_IMPORTED_MODULE_0___default.a.join(__dirname, "assets", "dictionary.json");
+  const dictionaryPath = path__WEBPACK_IMPORTED_MODULE_0___default.a.join(process.cwd(), "assets", "dictionary.json");
   const content = fs__WEBPACK_IMPORTED_MODULE_1___default.a.readFileSync(dictionaryPath, "utf-8");
   res.json(content);
 }


### PR DESCRIPTION
This adds support for a `processCwd` configuration option, including updating the current Webpack test case to use a `path.join(process.cwd()` expression to ensure this is correctly locating assets.