### PR TITLE
Add missing `processCwd` type

### DIFF
--- a/node-file-trace.d.ts
+++ b/node-file-trace.d.ts
@@ -28,6 +28,7 @@ interface Stats {
 
 export interface NodeFileTraceOptions {
   base?: string;
+  processCwd?: string;
   ignore?: string | string[] | ((path: string) => boolean);
   analysis?: boolean | {
     emitGlobs?: boolean;


### PR DESCRIPTION
Added `processCwd` in #120 but forgot to add the typescript type.