### PR TITLE
Fix trailing slash handling

### DIFF
--- a/src/resolve-dependency.js
+++ b/src/resolve-dependency.js
@@ -21,7 +21,7 @@ function resolvePath (path, parent, job) {
 }
 
 function resolveFile (path, parent, job) {
-  if (path[path.length - 1] === '/') return;
+  if (path.endsWith('/')) return;
   path = job.realpath(path, parent);
   if (job.isFile(path)) return path;
   if (job.ts && path.startsWith(job.base) && path.substr(job.base.length).indexOf(sep + 'node_modules' + sep) === -1 && job.isFile(path + '.ts')) return path + '.ts';

--- a/src/resolve-dependency.js
+++ b/src/resolve-dependency.js
@@ -5,10 +5,13 @@ const { isAbsolute, resolve, sep } = require('path');
 // (package.json files are emitted as they are hit)
 module.exports = function resolveDependency (specifier, parent, job) {
   let resolved;
-  if (isAbsolute(specifier) || specifier === '.' || specifier === '..' || specifier.startsWith('./') || specifier.startsWith('../'))
-    resolved = resolvePath(resolve(parent, '..', specifier), parent, job);
-  else
+  if (isAbsolute(specifier) || specifier === '.' || specifier === '..' || specifier.startsWith('./') || specifier.startsWith('../')) {
+    const trailingSlash = specifier[specifier.length - 1] === '/' || specifier[specifier.lenggth - 1] === '\\';
+    resolved = resolvePath(resolve(parent, '..', specifier) + (trailingSlash ? '/' : ''), parent, job);
+  }
+  else {
     resolved = resolvePackage(specifier, parent, job);
+  }
   if (resolved.startsWith('node:')) return resolved;
   return job.realpath(resolved, parent);
 };
@@ -18,8 +21,8 @@ function resolvePath (path, parent, job) {
 }
 
 function resolveFile (path, parent, job) {
+  if (path[path.length - 1] === '/') return;
   path = job.realpath(path, parent);
-  if (path.endsWith(sep)) return;
   if (job.isFile(path)) return path;
   if (job.ts && path.startsWith(job.base) && path.substr(job.base.length).indexOf(sep + 'node_modules' + sep) === -1 && job.isFile(path + '.ts')) return path + '.ts';
   if (job.ts && path.startsWith(job.base) && path.substr(job.base.length).indexOf(sep + 'node_modules' + sep) === -1 && job.isFile(path + '.tsx')) return path + '.tsx';
@@ -29,6 +32,7 @@ function resolveFile (path, parent, job) {
 }
 
 function resolveDir (path, parent, job) {
+  if (path[path.length - 1] === '/') path = path.slice(0, -1);
   if (!job.isDir(path)) return;
   const realPjsonPath = job.realpath(path + sep + 'package.json', parent);
   const pjsonSource = job.readFile(realPjsonPath);

--- a/src/resolve-dependency.js
+++ b/src/resolve-dependency.js
@@ -6,7 +6,7 @@ const { isAbsolute, resolve, sep } = require('path');
 module.exports = function resolveDependency (specifier, parent, job) {
   let resolved;
   if (isAbsolute(specifier) || specifier === '.' || specifier === '..' || specifier.startsWith('./') || specifier.startsWith('../')) {
-    const trailingSlash = specifier.endsWith('/') || specifier.endsWith('\\');
+    const trailingSlash = specifier.endsWith('/');
     resolved = resolvePath(resolve(parent, '..', specifier) + (trailingSlash ? '/' : ''), parent, job);
   }
   else {

--- a/src/resolve-dependency.js
+++ b/src/resolve-dependency.js
@@ -32,7 +32,7 @@ function resolveFile (path, parent, job) {
 }
 
 function resolveDir (path, parent, job) {
-  if (path[path.length - 1] === '/') path = path.slice(0, -1);
+  if (path.endsWith('/')) path = path.slice(0, -1);
   if (!job.isDir(path)) return;
   const realPjsonPath = job.realpath(path + sep + 'package.json', parent);
   const pjsonSource = job.readFile(realPjsonPath);

--- a/src/resolve-dependency.js
+++ b/src/resolve-dependency.js
@@ -6,7 +6,7 @@ const { isAbsolute, resolve, sep } = require('path');
 module.exports = function resolveDependency (specifier, parent, job) {
   let resolved;
   if (isAbsolute(specifier) || specifier === '.' || specifier === '..' || specifier.startsWith('./') || specifier.startsWith('../')) {
-    const trailingSlash = specifier[specifier.length - 1] === '/' || specifier[specifier.lenggth - 1] === '\\';
+    const trailingSlash = specifier[specifier.length - 1] === '/' || specifier[specifier.length - 1] === '\\';
     resolved = resolvePath(resolve(parent, '..', specifier) + (trailingSlash ? '/' : ''), parent, job);
   }
   else {

--- a/src/resolve-dependency.js
+++ b/src/resolve-dependency.js
@@ -6,7 +6,7 @@ const { isAbsolute, resolve, sep } = require('path');
 module.exports = function resolveDependency (specifier, parent, job) {
   let resolved;
   if (isAbsolute(specifier) || specifier === '.' || specifier === '..' || specifier.startsWith('./') || specifier.startsWith('../')) {
-    const trailingSlash = specifier[specifier.length - 1] === '/' || specifier[specifier.length - 1] === '\\';
+    const trailingSlash = specifier.endsWith('/') || specifier.endsWith('\\');
     resolved = resolvePath(resolve(parent, '..', specifier) + (trailingSlash ? '/' : ''), parent, job);
   }
   else {

--- a/test/unit/file-folder-slash/file-folder.js
+++ b/test/unit/file-folder-slash/file-folder.js
@@ -1,0 +1,2 @@
+module.exports = 'file';
+

--- a/test/unit/file-folder-slash/file-folder/index.js
+++ b/test/unit/file-folder-slash/file-folder/index.js
@@ -1,0 +1,2 @@
+module.exports = 'folder';
+

--- a/test/unit/file-folder-slash/input.js
+++ b/test/unit/file-folder-slash/input.js
@@ -1,0 +1,2 @@
+require('./file-folder/');
+

--- a/test/unit/file-folder-slash/output.js
+++ b/test/unit/file-folder-slash/output.js
@@ -1,0 +1,4 @@
+[
+  "test/unit/file-folder-slash/file-folder/index.js",
+  "test/unit/file-folder-slash/input.js"
+]


### PR DESCRIPTION
This fixes up the resolution of specifiers with a trailing slash to ensure they skip file resolution when there exists a file by the same name.

Fixes https://github.com/vercel/node-file-trace/issues/127