### PR TITLE
[ci] Add 15 minute timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [10, 12, 14]
+        node: [10, 12]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,11 @@ on:
 jobs:
   test:
     name: Test on node ${{ matrix.node }} and ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [10, 12]
+        node: [10, 12, 14]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Currently, CI takes about 10 minutes max to complete.

This PR adds a 15 minute timeout in the case where a PR introduces and infinite loop, such as #129.