### PR TITLE
Additional TypeScript Cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "prepublishOnly": "tsc && rm out/tsconfig.tsbuildinfo",
     "test": "jest --verbose",
     "test-verbose": "jest --verbose --coverage --globals \"{\\\"coverage\\\":true}\"",
     "codecov": "codecov",

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -1,4 +1,4 @@
-import { NodeFileTraceOptions, Stats } from './types';
+import { NodeFileTraceOptions, NodeFileTraceResult, NodeFileTraceReasons, Stats } from './types';
 import { basename, dirname, extname, relative, resolve, sep } from 'path';
 import fs from 'fs';
 import analyze, { AnalyzeResult } from './analyze';
@@ -13,7 +13,7 @@ function inPath (path: string, parent: string) {
   return path.startsWith(parent) && path[parent.length] === sep;
 }
 
-export async function nodeFileTrace(files: string[], opts: NodeFileTraceOptions = {}) {
+export async function nodeFileTrace(files: string[], opts: NodeFileTraceOptions = {}): Promise<NodeFileTraceResult> {
   const job = new Job(opts);
 
   if (opts.readFile)
@@ -34,12 +34,13 @@ export async function nodeFileTrace(files: string[], opts: NodeFileTraceOptions 
     return undefined;
   }));
 
-  return {
+  const result: NodeFileTraceResult = {
     fileList: [...job.fileList].sort(),
     esmFileList: [...job.esmFileList].sort(),
     reasons: job.reasons,
     warnings: [...job.warnings]
   };
+  return result;
 };
 
 export class Job {
@@ -61,7 +62,7 @@ export class Job {
   public esmFileList: Set<string>;
   public processed: Set<string>;
   public warnings: Set<Error>;
-  public reasons = Object.create(null);
+  public reasons: NodeFileTraceReasons = Object.create(null);
   
   constructor ({
     base = process.cwd(),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     "declaration": true,
     "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "incremental": true,
     "lib": ["esnext"],
     "module": "commonjs",
     "moduleResolution": "node",
@@ -14,6 +16,7 @@
     "outDir": "out",
     "target": "esnext",
     "types": ["node"],
+    "skipLibCheck": true,
     "strict": true
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
Follow up to #133

- Add `prepublishOnly` so we dont forget to compile before publishing to npm
- Add missing return type from nodeFileTrace() function
- Add a few [compiler options](https://www.typescriptlang.org/docs/handbook/compiler-options.html) for faster compilation