### PR TITLE
Fix ts exports and code coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,14 @@
 module.exports = {
-  collectCoverageFrom: ["src/**/*.js"],
+  collectCoverageFrom: ["out/**/*.js"],
   coverageReporters: ["html", "lcov"],
+  coverageThreshold: {
+    global: {
+      branches: 68.3,
+      functions: 81.89,
+      lines: 73.4,
+      statements: -364
+    }
+  },
   testEnvironment: "node",
   testMatch: ["<rootDir>/test/*(*.)@(spec|test).js?(x)"]
 };

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.7.0",
   "repository": "vercel/node-file-trace",
   "license": "MIT",
-  "main": "./out/node-file-trace.js",
-  "types": "./out/node-file-trace.d.ts",
+  "main": "./out/index.js",
+  "types": "./out/index.d.ts",
   "bin": {
     "nft": "./out/cli.js"
   },
@@ -12,9 +12,8 @@
     "build": "tsc",
     "prepublishOnly": "tsc && rm out/tsconfig.tsbuildinfo",
     "test": "jest --verbose",
-    "test-verbose": "jest --verbose --coverage --globals \"{\\\"coverage\\\":true}\"",
-    "codecov": "codecov",
-    "test-coverage": "jest --verbose --coverage --globals \"{\\\"coverage\\\":true}\" && codecov"
+    "test-verbose": "tsc --sourceMap && jest --verbose --coverage --globals \"{\\\"coverage\\\":true}\"",
+    "codecov": "codecov"
   },
   "files": [
     "out"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export { nodeFileTrace } from './node-file-trace';


### PR DESCRIPTION
- Created `index.ts` file as the main entrypoint so we can selectively export types, etc
- Fixed code coverage which was not pattern matching any files
- Added coverage threshold so CI fails if we ever drop below our current coverage