### PR TITLE
Fix usage in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ npm i @zeit/node-file-trace
 Provide the list of source files as input:
 
 ```js
-const nodeFileTrace = require('@zeit/node-file-trace');
+const { nodeFileTrace } = require('@zeit/node-file-trace');
 const files = ['./src/main.js', './src/second.js'];
 const { fileList } = await nodeFileTrace(files);
 ```


### PR DESCRIPTION
Version [0.8.0](https://github.com/vercel/node-file-trace/releases/tag/0.8.0) introduced the named export but the docs were not updated. This PR updates the docs to match the correct usage.

Fixes #140 