### PR TITLE
Ensure webpack wrapper statement existence checks

### DIFF
--- a/src/utils/wrappers.ts
+++ b/src/utils/wrappers.ts
@@ -305,6 +305,7 @@ export function handleWrappers(ast: Node) {
     else if (wrapper.callee.type === 'FunctionExpression' &&
         wrapper.callee.params.length === 1 &&
         wrapper.callee.body.body.length > 2 &&
+        wrapper.callee.body.body[0] &&
         wrapper.callee.body.body[0].type === 'VariableDeclaration' &&
         wrapper.callee.body.body[0].declarations.length === 1 &&
         wrapper.callee.body.body[0].declarations[0].type === 'VariableDeclarator' &&
@@ -315,14 +316,15 @@ export function handleWrappers(ast: Node) {
           wrapper.callee.body.body[0].declarations[0].init.type === 'CallExpression' &&
           wrapper.callee.body.body[0].declarations[0].init.arguments.length === 1
         ) &&
-        (wrapper.callee.body.body[1].type === 'FunctionDeclaration' &&
+        (wrapper.callee.body.body[1] &&
+          wrapper.callee.body.body[1].type === 'FunctionDeclaration' &&
           wrapper.callee.body.body[1].params.length === 1 &&
           wrapper.callee.body.body[1].body.body.length >= 3 ||
+          wrapper.callee.body.body[2] &&
           wrapper.callee.body.body[2].type === 'FunctionDeclaration' &&
           wrapper.callee.body.body[2].params.length === 1 &&
           wrapper.callee.body.body[2].body.body.length >= 3
         ) && (
-          wrapper.arguments[0] &&
           wrapper.arguments[0].type === 'ArrayExpression' &&
           wrapper.arguments[0].elements.length > 0 &&
           wrapper.arguments[0].elements.every((el: any) => el && el.type === 'FunctionExpression') ||

--- a/src/utils/wrappers.ts
+++ b/src/utils/wrappers.ts
@@ -305,7 +305,6 @@ export function handleWrappers(ast: Node) {
     else if (wrapper.callee.type === 'FunctionExpression' &&
         wrapper.callee.params.length === 1 &&
         wrapper.callee.body.body.length > 2 &&
-        wrapper.callee.body.body[0] &&
         wrapper.callee.body.body[0].type === 'VariableDeclaration' &&
         wrapper.callee.body.body[0].declarations.length === 1 &&
         wrapper.callee.body.body[0].declarations[0].type === 'VariableDeclarator' &&


### PR DESCRIPTION
As a follow-up to https://github.com/vercel/node-file-trace/pull/147 I just realised these statement checks can in theory cause undefined errors (like some previous bug cases).

This updates those checks to always ensure existence so they don't fail.