### PR TITLE
Rename package to @vercel/nft

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019 ZEIT, Inc.
+Copyright 2019 Vercel, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@zeit/node-file-trace",
+  "name": "@vercel/nft",
   "version": "0.8.2",
-  "repository": "vercel/node-file-trace",
+  "repository": "vercel/nft",
   "license": "MIT",
   "main": "./out/index.js",
   "types": "./out/index.d.ts",
@@ -48,7 +48,6 @@
     "@types/glob": "^7.1.2",
     "@types/micromatch": "^4.0.1",
     "@types/node": "^14.0.14",
-    "@zeit/ncc": "^0.17.0",
     "analytics-node": "^3.4.0-beta.1",
     "apollo-server-express": "^2.14.2",
     "argon2": "^0.24.0",

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # Node File Trace
 
-[![CI Status](https://badgen.net/github/checks/vercel/node-file-trace?label=CI)](https://github.com/vercel/node-file-trace/actions?workflow=CI)
-[![Code Coverage](https://badgen.net/codecov/c/github/vercel/node-file-trace)](https://codecov.io/gh/vercel/node-file-trace)
+[![CI Status](https://badgen.net/github/checks/vercel/nft?label=CI)](https://github.com/vercel/nft/actions?workflow=CI)
+[![Code Coverage](https://badgen.net/codecov/c/github/vercel/nft)](https://codecov.io/gh/vercel/nft)
 
 This package is used in [@vercel/node](https://npmjs.com/package/@vercel/node) and [@vercel/next](https://npmjs.com/package/@vercel/next) to determine exactly which files (including `node_modules`) are necessary for the application runtime.
 

--- a/readme.md
+++ b/readme.md
@@ -5,13 +5,13 @@
 
 This package is used in [@vercel/node](https://npmjs.com/package/@vercel/node) and [@vercel/next](https://npmjs.com/package/@vercel/next) to determine exactly which files (including `node_modules`) are necessary for the application runtime.
 
-This is similar to [@zeit/ncc](https://npmjs.com/package/@zeit/ncc) except there is no bundling performed and therefore no reliance on webpack. This achieves the same tree-shaking benefits without moving any assets or binaries.
+This is similar to [@vercel/ncc](https://npmjs.com/package/@vercel/ncc) except there is no bundling performed and therefore no reliance on webpack. This achieves the same tree-shaking benefits without moving any assets or binaries.
 
 ## Usage
 
 ### Installation
 ```bash
-npm i @zeit/node-file-trace
+npm i @vercel/nft
 ```
 
 ### Usage
@@ -19,7 +19,7 @@ npm i @zeit/node-file-trace
 Provide the list of source files as input:
 
 ```js
-const { nodeFileTrace } = require('@zeit/node-file-trace');
+const { nodeFileTrace } = require('@vercel/nft');
 const files = ['./src/main.js', './src/second.js'];
 const { fileList } = await nodeFileTrace(files);
 ```

--- a/yarn.lock
+++ b/yarn.lock
@@ -1546,11 +1546,6 @@
   dependencies:
     tslib "^1.9.3"
 
-"@zeit/ncc@^0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.17.0.tgz#f6121a15cf7ec76a65c17a3aa7d38e98151ea76e"
-  integrity sha512-PEu1L+bqj5c/BbkmBu3IRKOP10jprmJu4+EtHaFBQzeTfGcXnzbrssUVhzXpGi2X6Dw5S1FvwLWFGP3X5uEKYA==
-
 Base64@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/Base64/-/Base64-1.1.0.tgz#810ef21afa8357df92ad7b5389188c446b9cb956"
@@ -9757,7 +9752,6 @@ npm@^6.14.6:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -9772,7 +9766,6 @@ npm@^6.14.6:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.8"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -9791,14 +9784,8 @@ npm@^6.14.6:
     libnpx "^10.2.2"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"


### PR DESCRIPTION
- Rename package from `@zeit/node-file-trace` to `@vercel/nft`
- Rename repository from `vercel/node-file-trace` to `vercel/nft` (will do once merged)
- Update company name in LICENSE
- Remove unused `@zeit/ncc` dev dependency